### PR TITLE
Migration to Liteflow

### DIFF
--- a/MESGServices/Application/index.js
+++ b/MESGServices/Application/index.js
@@ -1,24 +1,24 @@
-const Application = require("@mesg/application");
-const mesg = new Application();
+const Application = require("@liteflow/application");
+const liteflow = new Application();
 
 async function main() {
-  mesg
+  liteflow
     .listenEvent({
       filter: {
-        instanceHash: await mesg.resolve("CDPWeb3Alerter"),
+        instanceHash: await liteflow.resolve("CDPWeb3Alerter"),
         key: "alert",
       },
     })
     .on("data", async (event) => {
-      const alert = mesg.decodeData(event.data);
+      const alert = liteflow.decodeData(event.data);
 
       console.log("... sending Telegram Message")
       try {
-        const result = await mesg.executeTaskAndWaitResult({
-          executorHash: await mesg.resolveRunner("telegram-send-msg"),
+        const result = await liteflow.executeTaskAndWaitResult({
+          executorHash: await liteflow.resolveRunner("telegram-send-msg"),
           taskKey: "send",
           eventHash: event.hash,
-          inputs: mesg.encodeData({
+          inputs: liteflow.encodeData({
             chatid: alert.chatid,
             message: alert.message
           }),
@@ -29,7 +29,7 @@ async function main() {
         }
         console.log(
           "task send return status",
-          mesg.decodeData(result.outputs).status
+          liteflow.decodeData(result.outputs).status
         );
       } catch (err) {
         console.error(err.message);

--- a/MESGServices/CDPWeb3Alerter/index.js
+++ b/MESGServices/CDPWeb3Alerter/index.js
@@ -1,5 +1,5 @@
-const Service = require('@mesg/service')
-const mesg = new Service()
+const Service = require('@liteflow/service')
+const liteflow = new Service()
 
 const web3 = require("web3");
 

--- a/MESGServices/telegram-send-msg/index.js
+++ b/MESGServices/telegram-send-msg/index.js
@@ -1,11 +1,11 @@
-const Service = require('@mesg/service')
+const Service = require('@liteflow/service')
 
-const mesg = new Service()
+const liteflow = new Service()
 
-mesg.listenTask({
+liteflow.listenTask({
   taskX: require('./tasks/send')
 })
   .on('error', (error) => console.error(error))
 
-mesg.emitEvent('started', { x: true })
+liteflow.emitEvent('started', { x: true })
   .catch((error) => console.error(error))


### PR DESCRIPTION
Here is a PR to migrate your service from MESG to Liteflow. 

I'm the founder of MESG, and we recently launched a new product called [Liteflow](https://liteflow.com/?utm_source=github&utm_medium=pull_request&utm_campaign=migration), a cloud-based version of MESG. All services can be migrated to Liteflow. You can have more details on [https://blog.mesg.com/why-did-we-build-liteflow](https://blog.mesg.com/why-did-we-build-liteflow?utm_source=github&utm_medium=pull_request&utm_campaign=migration/).

With this modification, you can now use this service in a [Liteflow application](https://docs.liteflow.com/?utm_source=github&utm_medium=pull_request&utm_campaign=migration) and monitor it with the new [Console](https://console.liteflow.com/?utm_source=github&utm_medium=pull_request&utm_campaign=migration).

Contact me if you need any information about Liteflow.